### PR TITLE
Github Moodle Plugin CI Actions updated.

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres:13
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -16,7 +16,7 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
       mariadb:
-        image: mariadb:10.5
+        image: mariadb:10.6
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"
@@ -28,6 +28,42 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - php: 8.2
+            moodle-branch: MOODLE_403_STABLE
+            database: pgsql
+          - php: 8.2
+            moodle-branch: MOODLE_403_STABLE
+            database: mariadb
+          - php: 8.1
+            moodle-branch: MOODLE_403_STABLE
+            database: pgsql
+          - php: 8.1
+            moodle-branch: MOODLE_403_STABLE
+            database: mariadb
+          - php: 8.0
+            moodle-branch: MOODLE_403_STABLE
+            database: pgsql
+          - php: 8.0
+            moodle-branch: MOODLE_403_STABLE
+            database: mariadb
+          - php: 8.2
+            moodle-branch: MOODLE_402_STABLE
+            database: pgsql
+          - php: 8.2
+            moodle-branch: MOODLE_402_STABLE
+            database: mariadb
+          - php: 8.1
+            moodle-branch: MOODLE_402_STABLE
+            database: pgsql
+          - php: 8.1
+            moodle-branch: MOODLE_402_STABLE
+            database: mariadb
+          - php: 8.0
+            moodle-branch: MOODLE_402_STABLE
+            database: pgsql
+          - php: 8.0
+            moodle-branch: MOODLE_402_STABLE
+            database: mariadb
           - php: 8.1
             moodle-branch: MOODLE_401_STABLE
             database: pgsql
@@ -57,56 +93,6 @@ jobs:
             database: pgsql
           - php: 7.4
             moodle-branch: MOODLE_400_STABLE
-            database: mariadb
-          - php: 7.4
-            moodle-branch: MOODLE_311_STABLE
-            database: pgsql
-          - php: 7.4
-            moodle-branch: MOODLE_311_STABLE
-            database: mariadb
-          - php: 7.4
-            moodle-branch: MOODLE_310_STABLE
-            database: pgsql
-          - php: 7.4
-            moodle-branch: MOODLE_310_STABLE
-            database: mariadb
-          - php: 7.4
-            moodle-branch: MOODLE_39_STABLE
-            database: pgsql
-          - php: 7.4
-            moodle-branch: MOODLE_39_STABLE
-            database: mariadb
-
-          - php: 7.3
-            moodle-branch: MOODLE_311_STABLE
-            database: pgsql
-          - php: 7.3
-            moodle-branch: MOODLE_311_STABLE
-            database: mariadb
-          - php: 7.3
-            moodle-branch: MOODLE_310_STABLE
-            database: pgsql
-          - php: 7.3
-            moodle-branch: MOODLE_310_STABLE
-            database: mariadb
-          - php: 7.3
-            moodle-branch: MOODLE_39_STABLE
-            database: pgsql
-          - php: 7.3
-            moodle-branch: MOODLE_39_STABLE
-            database: mariadb
-
-          - php: 7.2
-            moodle-branch: MOODLE_310_STABLE
-            database: pgsql
-          - php: 7.2
-            moodle-branch: MOODLE_310_STABLE
-            database: mariadb
-          - php: 7.2
-            moodle-branch: MOODLE_39_STABLE
-            database: pgsql
-          - php: 7.2
-            moodle-branch: MOODLE_39_STABLE
             database: mariadb
 
     steps:


### PR DESCRIPTION
Dear @gthomas2.
What do you think about adding the actions for Moodle 4.2 and Moodle 4.3 along to the CI integration (you might have to turn them on)? I think we can drop support to Moodle ≤ 3.11.
One more thing is that it might break with the YAML library which probably – in the included version – doesn't support PHP 8.2 yet.
It might be wise to upgrade to current https://github.com/dallgoot/yaml 0.9.1.1. therefore.